### PR TITLE
Ideas for DomBuilder::children() API

### DIFF
--- a/examples/animation/src/lib.rs
+++ b/examples/animation/src/lib.rs
@@ -152,7 +152,7 @@ pub fn main_js() -> Result<(), JsValue> {
             html!("div", {
                 .style("display", "flex")
 
-                .children(&mut [
+                .children(vec![
                     html!("div", {
                         .children_signal_vec(state.boxes.signal_vec()
                             .animated_map(2000.0, |value, t| {

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -41,7 +41,7 @@ impl State {
         html!("div", {
             .class(&*ROOT_CLASS)
 
-            .children(&mut [
+            .children(vec![
                 html!("div", {
                     .class(&*TEXT_CLASS)
                     .text_signal(state.counter.signal().map(|x| format!("Counter: {}", x)))

--- a/examples/todomvc/src/app.rs
+++ b/examples/todomvc/src/app.rs
@@ -101,7 +101,7 @@ impl App {
     fn render_header(app: Rc<Self>) -> Dom {
         html!("header", {
             .class("header")
-            .children(&mut [
+            .children(vec![
                 html!("h1", {
                     .text("todos")
                 }),
@@ -136,7 +136,7 @@ impl App {
                 .len()
                 .map(|len| len > 0))
 
-            .children(&mut [
+            .children(vec![
                 html!("input", {
                     .class("toggle-all")
                     .attribute("id", "toggle-all")
@@ -165,7 +165,7 @@ impl App {
 
     fn render_button(text: &str, route: Route) -> Dom {
         html!("li", {
-            .children(&mut [
+            .children(vec![
                 link!(route.url(), {
                     .text(text)
                     .class_signal("selected", Route::signal().map(move |x| x == route))
@@ -183,11 +183,11 @@ impl App {
                 .len()
                 .map(|len| len > 0))
 
-            .children(&mut [
+            .children(vec![
                 html!("span", {
                     .class("todo-count")
 
-                    .children(&mut [
+                    .children(vec![
                         html!("strong", {
                             .text_signal(app.not_completed_len().map(|len| len.to_string()))
                         }),
@@ -204,7 +204,7 @@ impl App {
 
                 html!("ul", {
                     .class("filters")
-                    .children(&mut [
+                    .children(vec![
                         Self::render_button("All", Route::All),
                         Self::render_button("Active", Route::Active),
                         Self::render_button("Completed", Route::Completed),
@@ -231,7 +231,7 @@ impl App {
     pub fn render(app: Rc<Self>) -> Dom {
         html!("section", {
             .class("todoapp")
-            .children(&mut [
+            .children(vec![
                 Self::render_header(app.clone()),
                 Self::render_main(app.clone()),
                 Self::render_footer(app.clone()),

--- a/examples/todomvc/src/todo.rs
+++ b/examples/todomvc/src/todo.rs
@@ -74,10 +74,10 @@ impl Todo {
                 )
                 .dedupe())
 
-            .children(&mut [
+            .children(vec![
                 html!("div", {
                     .class("view")
-                    .children(&mut [
+                    .children(vec![
                         html!("input", {
                             .attribute("type", "checkbox")
                             .class("toggle")

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -559,9 +559,11 @@ impl<A> DomBuilder<A> where A: AsRef<Node> {
         self.has_children = true;
     }
 
-    // TODO figure out how to make this owned rather than &mut
     #[inline]
-    pub fn children<'a, B: IntoIterator<Item = &'a mut Dom>>(mut self, children: B) -> Self {
+    pub fn children<B>(mut self, children: B) -> Self
+        where
+            B: IntoIterator<Item = Dom>,
+    {
         self.check_children();
         operations::insert_children_iter(self.element.as_ref(), &mut self.callbacks, children);
         self

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -560,9 +560,10 @@ impl<A> DomBuilder<A> where A: AsRef<Node> {
     }
 
     #[inline]
-    pub fn children<B>(mut self, children: B) -> Self
+    pub fn children<B, C>(mut self, children: B) -> Self
         where
-            B: IntoIterator<Item = Dom>,
+            B: IntoIterator<Item = C>,
+            C: Into<Dom>,
     {
         self.check_children();
         operations::insert_children_iter(self.element.as_ref(), &mut self.callbacks, children);
@@ -918,6 +919,11 @@ impl<A> DomBuilder<A> where A: AsRef<HtmlElement> {
     }
 }
 
+impl<A> From<DomBuilder<A>> for Dom where A: Into<Node> {
+    fn from(builder: DomBuilder<A>) -> Self {
+        builder.into_dom()
+    }
+}
 
 // TODO better warning message for must_use
 #[must_use]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -54,11 +54,13 @@ fn for_each_vec<A, B>(signal: A, mut callback: B) -> CancelableFutureHandle
 
 
 #[inline]
-pub(crate) fn insert_children_iter<A>(element: &Node, callbacks: &mut Callbacks, children: A)
+pub(crate) fn insert_children_iter<A, B>(element: &Node, callbacks: &mut Callbacks, children: A)
     where
-        A: IntoIterator<Item = Dom>,
+        A: IntoIterator<Item = B>,
+        B: Into<Dom>,
 {
-    for mut dom in children.into_iter() {
+    for child in children.into_iter() {
+        let mut dom: Dom = child.into();
         // TODO can this be made more efficient ?
         callbacks.after_insert.append(&mut dom.callbacks.after_insert);
         callbacks.after_remove.append(&mut dom.callbacks.after_remove);

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -54,8 +54,11 @@ fn for_each_vec<A, B>(signal: A, mut callback: B) -> CancelableFutureHandle
 
 
 #[inline]
-pub(crate) fn insert_children_iter<'a, A: IntoIterator<Item = &'a mut Dom>>(element: &Node, callbacks: &mut Callbacks, value: A) {
-    for dom in value.into_iter() {
+pub(crate) fn insert_children_iter<A>(element: &Node, callbacks: &mut Callbacks, children: A)
+    where
+        A: IntoIterator<Item = Dom>,
+{
+    for mut dom in children.into_iter() {
         // TODO can this be made more efficient ?
         callbacks.after_insert.append(&mut dom.callbacks.after_insert);
         callbacks.after_remove.append(&mut dom.callbacks.after_remove);


### PR DESCRIPTION
Two ideas for `DomBuilder::children()`:
1. How about passing children elements as-owned instead of by-reference? There was a comment in the code indicating that you wanted to do that. It means we need to usually create a Vector instead of an array of Dom elements, because [IntoIterator is not implemented for arrays](https://github.com/rust-lang/rust/issues/25725).
2. How about accepting not only `Dom`, but more generally `Into<Dom>`, and then implementing the corresponding conversion for `DomBuilder`?

Change 1) would make it easier to make a "children" list of Dom elements from any iterator/collection. I'm often `collect()`ing to `Vec`, and then converting to a slice with `as_mut_slice()`.

Change 2) could be useful because it will allow to create Dom elements more easily without macros. For example:
```rust
.children(vec![
    html("div")
        .text("Hello World"),
    html("button")
        .text("Increase")
        .event({
            let state = state.clone();
            move |_: events::Click| {
                state.counter.replace_with(|x| *x + 1);
            }
        }),
])
```
Where `html()` is a function to create a DomBuilder like this:
```rust
fn html(name: &str) -> DomBuilder<web_sys::HtmlElement> {
    DomBuilder::new_html(name)
}
```

Of course I'm just opening this to get your opinion on these ideas, maybe there are good reasons why it's not that way?