### PR TITLE
Update README.md: does not require nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ It is generally feature complete, though more convenience methods might be added
 
 It is relatively stable: breaking changes are rare, and are handled with the normal semver system.
 
-You must use the Nightly Rust compiler (because it is needed for futures 0.3)
-
 Running the examples
 ====================
 


### PR DESCRIPTION
Futures now compile on stable, so this note seems unnecessary