### PR TITLE
Make methods less internal

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -473,8 +473,7 @@ impl<A> DomBuilder<A> {
 
 impl<A> DomBuilder<A> where A: Clone {
     #[inline]
-    #[doc(hidden)]
-    pub fn __internal_element(&self) -> A {
+    pub fn element(&self) -> A {
         self.element.clone()
     }
 
@@ -516,6 +515,10 @@ impl<A> DomBuilder<A> where A: Into<Node> {
             element: self.element.into(),
             callbacks: self.callbacks,
         }
+    }
+    #[inline]
+    pub fn finish(self) -> Dom {
+        self.into_dom()
     }
 }
 
@@ -991,9 +994,8 @@ pub struct StylesheetBuilder {
 // TODO remove the CssStyleRule when this is discarded
 impl StylesheetBuilder {
     // TODO should this inline ?
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_new<A>(selector: A) -> Self where A: MultiStr {
+    pub fn new<A>(selector: A) -> Self where A: MultiStr {
         // TODO can this be made faster ?
         // TODO somehow share this safely between threads ?
         thread_local! {
@@ -1073,8 +1075,7 @@ impl StylesheetBuilder {
 
     // TODO return a Handle
     #[inline]
-    #[doc(hidden)]
-    pub fn __internal_done(mut self) {
+    pub fn finish(mut self) {
         self.callbacks.trigger_after_insert();
 
         // This prevents it from triggering after_remove
@@ -1091,21 +1092,19 @@ pub struct ClassBuilder {
 }
 
 impl ClassBuilder {
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_new() -> Self {
+    pub fn new() -> Self {
         let class_name = __internal::make_class_id();
 
         Self {
             // TODO make this more efficient ?
-            stylesheet: StylesheetBuilder::__internal_new(&format!(".{}", class_name)),
+            stylesheet: StylesheetBuilder::new(&format!(".{}", class_name)),
             class_name,
         }
     }
 
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_class_name(&self) -> &str {
+    pub fn class_name(&self) -> &str {
         &self.class_name
     }
 
@@ -1148,10 +1147,9 @@ impl ClassBuilder {
     }
 
     // TODO return a Handle ?
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_done(self) -> String {
-        self.stylesheet.__internal_done();
+    pub fn finish(self) -> String {
+        self.stylesheet.finish();
         self.class_name
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! __internal_builder {
 #[macro_export]
 macro_rules! with_node {
     ($this:ident, $name:ident => { $($methods:tt)* }) => {{
-        let $name = $crate::DomBuilder::__internal_element(&$this);
+        let $name = $crate::DomBuilder::element(&$this);
         $crate::apply_methods!($this, { $($methods)* })
     }};
 }
@@ -100,7 +100,7 @@ macro_rules! stylesheet {
         $crate::stylesheet!($rule, {})
     };
     ($rule:expr, { $($methods:tt)* }) => {
-        $crate::StylesheetBuilder::__internal_done($crate::apply_methods!($crate::StylesheetBuilder::__internal_new($rule), { $($methods)* }))
+        $crate::StylesheetBuilder::finish($crate::apply_methods!($crate::StylesheetBuilder::new($rule), { $($methods)* }))
     };
 }
 
@@ -108,7 +108,7 @@ macro_rules! stylesheet {
 #[macro_export]
 macro_rules! class {
     ($($methods:tt)*) => {{
-        $crate::ClassBuilder::__internal_done($crate::apply_methods!($crate::ClassBuilder::__internal_new(), { $($methods)* }))
+        $crate::ClassBuilder::finish($crate::apply_methods!($crate::ClassBuilder::new(), { $($methods)* }))
     }};
 }
 
@@ -119,7 +119,7 @@ macro_rules! pseudo {
         $crate::pseudo!($this, $rules, {})
     };
     ($this:ident, $rules:expr, { $($methods:tt)* }) => {{
-        $crate::stylesheet!($crate::__internal::Pseudo::new($crate::ClassBuilder::__internal_class_name(&$this), $rules), { $($methods)* });
+        $crate::stylesheet!($crate::__internal::Pseudo::new($crate::ClassBuilder::class_name(&$this), $rules), { $($methods)* });
         $this
     }};
 }


### PR DESCRIPTION
This pull request makes quite a lot of `__internal_` things on `DomBuilder`, `StylesheetBuilder`, `ClassBuilder` visible from outside.

Why do I want this?

* Currently, the only way to use these methods are from utility macros, despite them being perfectly fine usable by themselves.
For example, instead of just doing `ClassBuilder::new().style("foo", "bar").finish()`, I am forced to call the macro.
Similarly, the `with_node!` macro only works within a `html!` context, and not a `DomBuilder::new_html("foo")....into_dom()`
* Without the methods being public, its hard to make custom macros, as I have to directly inspect the source code.
* As the macros to access the methods are currently undocumented, it is difficult to see which macro should be used. For example, from looking at the `ClassBuilder` documentation it is unclear how to generate one; this could also be solved by documenting the macros, but that might better be served by exposing the methods and saying "You can also use `with_node!`".

This pull request also adds a `finish()` method to `DomBuilder`, in order to make its api more similar to `StylesheetBuilder` and `ClassBuilder`, which both are given `finish()` methods.

