### PR TITLE
Adds a small method to set the class name in a ClassBuilder

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1224,6 +1224,12 @@ impl ClassBuilder {
     }
 
     #[inline]
+    pub fn class_name(mut self, name: String) -> Self {
+        self.class_name = name;
+        self
+    }
+
+    #[inline]
     pub fn style<B, C>(mut self, name: B, value: C) -> Self
         where B: MultiStr,
               C: MultiStr {


### PR DESCRIPTION
This allows a user to use existing class names that are used by javascript as well.

I'm unsure if `class_name` is a good name for that method or if `name` might be better