### PR TITLE
Support generics in dom builder methods

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,6 +12,10 @@ macro_rules! apply_methods {
         let this = $this.$name($($args),*);
         $crate::apply_methods!(this, { $($rest)* })
     }};
+    ($this:expr, { .$name:ident::<$($types:ty),*>($($args:expr),*) $($rest:tt)* }) => {{
+        let this = $this.$name::<$($types),*>($($args),*);
+        $crate::apply_methods!(this, { $($rest)* })
+    }};
 }
 
 


### PR DESCRIPTION
Previously, specifying generic types in methods with the `html!` and `apply_methods!` macros was not supported.

This PR adds support for these allowing you to do things such as:
```rust
html!("div", {
    .event::<dominator::events::MouseDown>(...)
})
```