### PR TITLE
Add block support to `apply_methods!` macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,6 +16,10 @@ macro_rules! apply_methods {
         let this = $this.$name::<$($types),*>($($args),*);
         $crate::apply_methods!(this, { $($rest)* })
     }};
+    ($this:expr, { |$this_ident:ident| $args:expr; $($rest:tt)* }) => {{
+        let $this_ident = $this;
+        $crate::apply_methods!($args, { $($rest)* })
+    }};
 }
 
 


### PR DESCRIPTION
Adds support for more dynamic methods in the `apply_methods!` macro.

This is done with the syntax of a closure.
```rust
html!("div", {
    |this| {
        this.event(...)
    };
});
```

This is needed for more advanced cases such as cases where you need to return data temporarily to a method.
For example, this doesn't work:
```rust
html!("div", {
    .text(match format_args("foo").as_str() {
        Some(s) => s,
        None => &format!("foo"), // Fails, because this does not live past the match block.
    })
});
```

With this PR, you can now do this instead:
```rs
html!("div", {
    |this| match format_args("foo").as_str() {
        Some(s) => this.text(s),
        None => this.text(&format!("foo")),
    };
});
```