### PR TITLE
add Into<Dom> parameter bounds

### DIFF
--- a/examples/counter_alt/.gitignore
+++ b/examples/counter_alt/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+/dist/js
+/target
+/wasm-pack.log
+/yarn-error.log

--- a/examples/counter_alt/Cargo.toml
+++ b/examples/counter_alt/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "counter"
+version = "0.1.0"
+description = "Counter demo using dominator"
+authors = ["Pauan <pauanyu+github@pm.me>"]
+categories = ["wasm"]
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+
+[profile.release]
+lto = true
+codegen-units = 1
+opt-level = 3  # 3 => fast, s/z => small
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O4"]  # O4 => fast, Oz/Os => small
+
+[lib]
+crate-type = ["cdylib"]
+
+[workspace]
+
+[dependencies]
+console_error_panic_hook = "0.1.6"
+dominator = { version = "0.5.18", path = "../../" }
+wasm-bindgen = "0.2.74"
+futures-signals = "0.3.20"
+once_cell = "1.7.2"

--- a/examples/counter_alt/README.md
+++ b/examples/counter_alt/README.md
@@ -1,0 +1,20 @@
+## How to install
+
+```sh
+yarn install
+```
+
+## How to build
+
+```sh
+# Builds the project and opens it in your browser.
+# It will auto-reload when you make any changes.
+yarn start
+```
+
+## How to build for production
+
+```sh
+# Builds the project and places it into the `dist` folder.
+yarn run build
+```

--- a/examples/counter_alt/dist/index.html
+++ b/examples/counter_alt/dist/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>rust-dominator • Counter</title>
+  </head>
+  <body>
+    <script src="js/index.js"></script>
+  </body>
+</html>

--- a/examples/counter_alt/package.json
+++ b/examples/counter_alt/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "author": "Pauan <pauanyu+github@pm.me>",
+  "name": "counter",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "rimraf dist/js && rollup --config",
+    "start": "rimraf dist/js && rollup --config --watch"
+  },
+  "devDependencies": {
+    "@wasm-tool/rollup-plugin-rust": "^1.0.6",
+    "rimraf": "^3.0.2",
+    "rollup": "^2.50.2",
+    "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-serve": "^1.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  }
+}

--- a/examples/counter_alt/rollup.config.js
+++ b/examples/counter_alt/rollup.config.js
@@ -1,0 +1,31 @@
+import rust from "@wasm-tool/rollup-plugin-rust";
+import serve from "rollup-plugin-serve";
+import livereload from "rollup-plugin-livereload";
+import { terser } from "rollup-plugin-terser";
+
+const is_watch = !!process.env.ROLLUP_WATCH;
+
+export default {
+    input: {
+        index: "./Cargo.toml",
+    },
+    output: {
+        dir: "dist/js",
+        format: "iife",
+        sourcemap: true,
+    },
+    plugins: [
+        rust({
+            serverPath: "js/",
+        }),
+
+        is_watch && serve({
+            contentBase: "dist",
+            open: true,
+        }),
+
+        is_watch && livereload("dist"),
+
+        !is_watch && terser(),
+    ],
+};

--- a/examples/counter_alt/src/lib.rs
+++ b/examples/counter_alt/src/lib.rs
@@ -1,0 +1,81 @@
+use dominator::{class, clone, el, events, Dom};
+use futures_signals::signal::{Mutable, SignalExt};
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+use wasm_bindgen::prelude::*;
+
+struct App {
+    counter: Mutable<i32>,
+}
+
+impl App {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            counter: Mutable::new(0),
+        })
+    }
+
+    fn render(state: Arc<Self>) -> impl Into<Dom> {
+        // Define CSS styles
+        static ROOT_CLASS: Lazy<String> = Lazy::new(|| {
+            class! {
+                .style("display", "inline-block")
+                .style("background-color", "black")
+                .style("padding", "10px")
+            }
+        });
+
+        static TEXT_CLASS: Lazy<String> = Lazy::new(|| {
+            class! {
+                .style("color", "white")
+                .style("font-weight", "bold")
+            }
+        });
+
+        static BUTTON_CLASS: Lazy<String> = Lazy::new(|| {
+            class! {
+                .style("display", "block")
+                .style("width", "100px")
+                .style("margin", "5px")
+            }
+        });
+
+        // Create the DOM nodes
+        el("div")
+            .class(&*ROOT_CLASS)
+            .children([
+                el("div")
+                    .class(&*TEXT_CLASS)
+                    .text_signal(state.counter.signal().map(|x| format!("Counter: {}", x))),
+                el("button").class(&*BUTTON_CLASS).text("Increase").event(
+                    clone!(state => move |_: events::Click| {
+                        // Increment the counter
+                        state.counter.replace_with(|x| *x + 1);
+                    }),
+                ),
+                el("button").class(&*BUTTON_CLASS).text("Decrease").event(
+                    clone!(state => move |_: events::Click| {
+                        // Decrement the counter
+                        state.counter.replace_with(|x| *x - 1);
+                    }),
+                ),
+                el("button").class(&*BUTTON_CLASS).text("Reset").event(
+                    clone!(state => move |_: events::Click| {
+                        // Reset the counter to 0
+                        state.counter.set_neq(0);
+                    }),
+                ),
+            ])
+    }
+}
+
+#[wasm_bindgen(start)]
+pub fn main_js() -> Result<(), JsValue> {
+    #[cfg(debug_assertions)]
+    console_error_panic_hook::set_once();
+
+    let app = App::new();
+    dominator::append_dom(&dominator::body(), App::render(app));
+
+    Ok(())
+}


### PR DESCRIPTION
Thanks for your excellent crate @Pauan. We've been using this for some applications and one thing we noticed was that rustfmt isn't able to format inside `html!` macro calls. 

In this PR I've trialed out changing some of the function parameter bounds from `BorrowMut<Dom>` to `Into<Dom>` which enables another style of writing elements as per the example in `counter_alt`. The primary way this helps is by avoiding `into_dom()` calls at the end of each element's chain of methods.

My intention in opening this is just as much to have a discussion as propose this change as I recognize this is a potentially breaking change and may not have that much value to other users of the crate, and there also may be alternative solutions to explore. 