### PR TITLE
Allow custom name for style

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1286,8 +1286,8 @@ impl ClassBuilder {
     #[doc(hidden)]
     #[inline]
     #[track_caller]
-    pub fn __internal_new() -> Self {
-        let class_name = __internal::make_class_id();
+    pub fn __internal_new(name: Option<&str>) -> Self {
+        let class_name = __internal::make_class_id(name);
 
         Self {
             // TODO make this more efficient ?
@@ -1387,7 +1387,7 @@ pub mod __internal {
     pub use web_sys::SvgElement;
 
 
-    pub fn make_class_id() -> String {
+    pub fn make_class_id(name: Option<&str>) -> String {
         // TODO replace this with a global counter in JavaScript ?
         // TODO can this be made more efficient ?
         static CLASS_ID: AtomicU32 = AtomicU32::new(0);
@@ -1396,10 +1396,10 @@ pub mod __internal {
         // TODO should this be SeqCst ?
         let id = CLASS_ID.fetch_add(1, Ordering::Relaxed);
 
+        let name = name.unwrap_or("__class_");
         // TODO make this more efficient ?
-        format!("__class_{}__", id)
+        format!("{}_{}", name, id)
     }
-
 
     pub struct Pseudo<'a, A> {
         class_name: &'a str,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -111,7 +111,7 @@ macro_rules! stylesheet {
 
 #[macro_export]
 macro_rules! class {
-    ($name:literal $($methods:tt)*) => {{
+    (#![prefix = $name:literal] $($methods:tt)*) => {{
         $crate::ClassBuilder::__internal_done($crate::apply_methods!($crate::ClassBuilder::__internal_new(Some($name)), { $($methods)* }))
     }};
     ($($methods:tt)*) => {{

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -111,8 +111,11 @@ macro_rules! stylesheet {
 
 #[macro_export]
 macro_rules! class {
+    ($name:literal $($methods:tt)*) => {{
+        $crate::ClassBuilder::__internal_done($crate::apply_methods!($crate::ClassBuilder::__internal_new(Some($name)), { $($methods)* }))
+    }};
     ($($methods:tt)*) => {{
-        $crate::ClassBuilder::__internal_done($crate::apply_methods!($crate::ClassBuilder::__internal_new(), { $($methods)* }))
+        $crate::ClassBuilder::__internal_done($crate::apply_methods!($crate::ClassBuilder::__internal_new(None), { $($methods)* }))
     }};
 }
 


### PR DESCRIPTION
Simple change adding variant into class! macro. The purpose is to ease development/debugging in browsers' devtools, where customized style names are far more descriptive.