### PR TITLE
Avoid panic & warn on empty class

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ futures-signals = "0.3.5"
 wasm-bindgen = "0.2.48"
 js-sys = "0.3.22"
 wasm-bindgen-futures = "0.4.9"
-gloo-events = "0.1.2"
+gloo-events = "0.2.0"
+gloo-console = "0.3.0"
 
 [dependencies.web-sys]
 version = "0.3.22"

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -925,7 +925,17 @@ impl<A> DomBuilder<A> where A: AsRef<Element> {
         let classes = self.element.as_ref().class_list();
 
         name.each(|name| {
-            bindings::add_class(&classes, intern(name));
+            // avoids adding an empty class and panicking
+            if !name.is_empty() {
+                bindings::add_class(&classes, intern(name));
+            }
+            else {
+                // warn in console
+                gloo_console::warn!(format!("Empty class detected in element ({}).", self.element.as_ref().tag_name().to_ascii_lowercase()));
+
+                // looks like track_caller won't help us here?
+                // gloo_console::warn!("Empty class near: {}", std::panic::Location::caller().to_string());
+            }
         });
 
         self


### PR DESCRIPTION
Hi Pauan,

This PR avoids the panic if you pass an empty `impl Multistr` to `DomBuilder::class` and warns in the console. 
Would you be open to merging this? Potentially without the warn (as it does require an extra dependency). Perhaps the message can be improved, very open to discussion/improvement.