### PR TITLE
Match web-sys unstable mouse and scroll types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,15 @@ license = "MIT"
 keywords = ["javascript", "dom", "reactive", "signal", "frp"]
 categories = ["gui", "web-programming", "wasm"]
 edition = "2018"
+rust-version = "1.80"
 
 [features]
 # TODO should this enable interning ?
 default = ["wasm-bindgen/enable-interning"]
 nightly = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
 
 [dependencies]
 once_cell = "1.7.2"

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -25,6 +25,28 @@ use crate::utils::{EventListener, on, RefCounter, MutableListener, UnwrapJsExt, 
 #[cfg(doc)]
 use crate::fragment;
 
+#[allow(unexpected_cfgs)]
+#[cfg(web_sys_unstable_apis)]
+macro_rules! scroll_signal_value_ty {
+    () => { f64 };
+}
+
+#[allow(unexpected_cfgs)]
+#[cfg(not(web_sys_unstable_apis))]
+macro_rules! scroll_signal_value_ty {
+    () => { i32 };
+}
+
+#[inline]
+fn set_scroll_left_from_signal(element: &Element, value: scroll_signal_value_ty!()) {
+    element.set_scroll_left(value);
+}
+
+#[inline]
+fn set_scroll_top_from_signal(element: &Element, value: scroll_signal_value_ty!()) {
+    element.set_scroll_top(value);
+}
+
 
 pub struct RefFn<A, B, C> where B: ?Sized, C: Fn(&A) -> &B {
     value: A,
@@ -1427,8 +1449,8 @@ impl<A> DomBuilder<A> where A: AsRef<Element> {
     // TODO should this inline ?
     // TODO track_caller
     fn set_scroll_signal<B, F>(&mut self, signal: B, mut f: F)
-        where B: Signal<Item = Option<i32>> + 'static,
-              F: FnMut(&Element, i32) + 'static {
+        where B: Signal<Item = Option<scroll_signal_value_ty!()>> + 'static,
+              F: FnMut(&Element, scroll_signal_value_ty!()) + 'static {
 
         let element: Element = self.element.as_ref().clone();
 
@@ -1445,18 +1467,18 @@ impl<A> DomBuilder<A> where A: AsRef<Element> {
     // TODO rename to scroll_x_signal ?
     #[inline]
     #[track_caller]
-    pub fn scroll_left_signal<B>(mut self, signal: B) -> Self where B: Signal<Item = Option<i32>> + 'static {
+    pub fn scroll_left_signal<B>(mut self, signal: B) -> Self where B: Signal<Item = Option<scroll_signal_value_ty!()>> + 'static {
         // TODO bindings function for this ?
-        self.set_scroll_signal(signal, Element::set_scroll_left);
+        self.set_scroll_signal(signal, set_scroll_left_from_signal);
         self
     }
 
     // TODO rename to scroll_y_signal ?
     #[inline]
     #[track_caller]
-    pub fn scroll_top_signal<B>(mut self, signal: B) -> Self where B: Signal<Item = Option<i32>> + 'static {
+    pub fn scroll_top_signal<B>(mut self, signal: B) -> Self where B: Signal<Item = Option<scroll_signal_value_ty!()>> + 'static {
         // TODO bindings function for this ?
-        self.set_scroll_signal(signal, Element::set_scroll_top);
+        self.set_scroll_signal(signal, set_scroll_top_from_signal);
         self
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -93,28 +93,28 @@ macro_rules! make_mouse_event {
         make_event!($name => $event);
 
         impl $name {
-            #[inline] pub fn x(&self) -> i32 { self.event.client_x() }
-            #[inline] pub fn y(&self) -> i32 { self.event.client_y() }
+            #[inline] pub fn x(&self) -> mouse_event_value_ty!() { self.event.client_x() }
+            #[inline] pub fn y(&self) -> mouse_event_value_ty!() { self.event.client_y() }
 
             #[inline] pub fn movement_x(&self) -> i32 { self.event.movement_x() }
             #[inline] pub fn movement_y(&self) -> i32 { self.event.movement_y() }
 
-            #[inline] pub fn offset_x(&self) -> i32 { self.event.offset_x() }
-            #[inline] pub fn offset_y(&self) -> i32 { self.event.offset_y() }
+            #[inline] pub fn offset_x(&self) -> mouse_event_value_ty!() { self.event.offset_x() }
+            #[inline] pub fn offset_y(&self) -> mouse_event_value_ty!() { self.event.offset_y() }
 
-            #[inline] pub fn page_x(&self) -> i32 { self.event.page_x() }
-            #[inline] pub fn page_y(&self) -> i32 { self.event.page_y() }
+            #[inline] pub fn page_x(&self) -> mouse_event_value_ty!() { self.event.page_x() }
+            #[inline] pub fn page_y(&self) -> mouse_event_value_ty!() { self.event.page_y() }
 
-            #[inline] pub fn screen_x(&self) -> i32 { self.event.screen_x() }
-            #[inline] pub fn screen_y(&self) -> i32 { self.event.screen_y() }
+            #[inline] pub fn screen_x(&self) -> mouse_event_value_ty!() { self.event.screen_x() }
+            #[inline] pub fn screen_y(&self) -> mouse_event_value_ty!() { self.event.screen_y() }
 
             #[inline] pub fn ctrl_key(&self) -> bool { self.event.ctrl_key() || self.event.meta_key() }
             #[inline] pub fn shift_key(&self) -> bool { self.event.shift_key() }
             #[inline] pub fn alt_key(&self) -> bool { self.event.alt_key() }
 
             // TODO maybe deprecate these ?
-            #[inline] pub fn mouse_x(&self) -> i32 { self.event.client_x() }
-            #[inline] pub fn mouse_y(&self) -> i32 { self.event.client_y() }
+            #[inline] pub fn mouse_x(&self) -> mouse_event_value_ty!() { self.event.client_x() }
+            #[inline] pub fn mouse_y(&self) -> mouse_event_value_ty!() { self.event.client_y() }
 
             pub fn button(&self) -> MouseButton {
                 match self.event.button() {
@@ -128,6 +128,18 @@ macro_rules! make_mouse_event {
             }
         }
     };
+}
+
+#[allow(unexpected_cfgs)]
+#[cfg(web_sys_unstable_apis)]
+macro_rules! mouse_event_value_ty {
+    () => { f64 };
+}
+
+#[allow(unexpected_cfgs)]
+#[cfg(not(web_sys_unstable_apis))]
+macro_rules! mouse_event_value_ty {
+    () => { i32 };
 }
 
 macro_rules! make_pointer_event {


### PR DESCRIPTION
Closes issue #87 

## Summary
- make mouse coordinate accessors follow web-sys and return `f64` when `web_sys_unstable_apis` is enabled
- make `scroll_left_signal` and `scroll_top_signal` use the matching unstable `f64` signal type
- declare `web_sys_unstable_apis` in Cargo lint config and set `rust-version = "1.80"`

## Verification
- `cargo check`
- `RUSTFLAGS="--cfg=web_sys_unstable_apis" cargo check --target wasm32-unknown-unknown`